### PR TITLE
Ajaxify - modified delta-loading, data-class="always"

### DIFF
--- a/ajaxify.js
+++ b/ajaxify.js
@@ -450,8 +450,8 @@ function getRootUrl(){var a=window.location.protocol+"//"+(window.location.hostn
                 $scriptsN = $sN;
             } 
             if (_allScripts($this, PK)) return true;
-            if (pass) _classAlways($this, PK);
-            if (same) return _sameScripts($scriptsN, PK);
+            if (same) { _classAlways($this, PK); return; }
+            //if (pass>1 && same) return _sameScripts($scriptsN, PK);
             $scriptsN = [];
             _newArray($this, $scriptsN, $scriptsO, PK);
             if (pass) {
@@ -481,7 +481,7 @@ function getRootUrl(){var a=window.location.protocol+"//"+(window.location.hostn
             $t.each(function () {
                 if ($(this).attr("data-class") == "always") {
                     _iScript($(this).attr(PK), PK);
-                    $(this).remove();
+                    //$(this).remove();
                 }
             });
         }


### PR DESCRIPTION
Please see 
- http://4nf.org/delta-loading/

...and the rest of 4nf.org for in-depth documentation

`data-class="always"` now must be specified for scripts that should be loaded all the time, 
i.e. even when the target page is the same as the current page
