### PR TITLE
Ajaxify - a nuisance specific to 4nf.org homepage

### DIFF
--- a/ajaxify.js
+++ b/ajaxify.js
@@ -272,8 +272,9 @@ pO("ajaxify", 0, { pluginon: true, deltas: true }, function ($this, options) {
     if(!o || typeof(o) !== 'string') {
         $(function () { //on DOMReady
             if (_init(settings)) { //sub-plugins initialisation
-                $this.pronto(0, settings); //Pronto initialisation
-                $this.pronto("i"); 
+                //$this.pronto(0, settings); //Pronto initialisation
+                //$this.pronto("i");
+                $this.pronto("i", settings);
                 if(deltas) $.scripts("1"); //delta-loading initialisation
             }
         });

--- a/ajaxify.js
+++ b/ajaxify.js
@@ -52,7 +52,7 @@ Options default values
     pluginon : true // Plugin set "on" or "off" (==false) manually
 }
 
-Animation parameters (aniParams):  Default is false (set off)
+Animation parameters (aniParams):  Default is false (set off) - specify aniTime and override the following aniParams:
 {
     opacity: 1, //no fade, set to 0 for maximum fade
     width: "100%", //in percent -  "100%" means no change
@@ -61,7 +61,7 @@ Animation parameters (aniParams):  Default is false (set off)
 
 More animation parameters
 
-You can specify any parameters that are understood by .animate() respectively…
+You can specify any parameters that are understood by .animate()
 
 */
 
@@ -266,9 +266,7 @@ pO("ajaxify", 0, { pluginon: true, deltas: true }, function ($this, options) {
     if(!o || typeof(o) !== 'string') {
         $(function () { //on DOMReady
             if (_init(settings)) { //sub-plugins initialisation
-                //$this.pronto(0, settings); //Pronto initialisation
-                //$this.pronto("i");
-                $this.pronto("i", settings);
+                $this.pronto("i", settings); //Pronto initialisation
                 if(deltas) $.scripts("1"); //delta-loading initialisation
             }
         });
@@ -825,13 +823,13 @@ pO("pronto", { $gthis: 0 }, { selector: "a:not(.no-ajaxy)", prefetch: true, prev
       $.rqTimer(function() { $.cd("1", _doRender); }); // Set.  Animate to
   },
  onPop: function(e) { // Handle back/forward navigation
-      $.rq("i");
-      $.rq("e", e);
+      $.rq("i"); //Initialise request in general
+      $.rq("e", e); //Initialise request event
             
       var data = e.originalEvent.state, url = data ? data.url : 0;
            
       if (!url || url === currentURL) return;  // Check if data exists
-      $.rq("s", url);
+      $.rq("s", url); // Set "same" variable
       _trigger("request"); // Fire request event
       fn(url, _render); // Call "fn" - handler of parent, continue with _render()
   },

--- a/ajaxify.js
+++ b/ajaxify.js
@@ -649,12 +649,12 @@ pO("rq", { ispost: 0, data: 0, same: 0, sema: 0, mode: 0, push: 0, can: 0, e: 0,
     if(o === "d") {
         if(p) data = p;
         return data;
-	}
+    }
 	
     if(o === "can") {
         if(p) can = p;
         return can;
-	}
+    }
 	
     if(o === "can?") return can && can !== p && !p.iO('#') && !p.iO('?') ? can : p;
 });

--- a/ajaxify.js
+++ b/ajaxify.js
@@ -178,7 +178,7 @@ pO("pages", { d: [] }, 0, function (h) {
 
 pO("getPage", { xhr: 0 }, 0, function (o, p, p2) { 
     if (!o) return $.cache();
-	if (o.iO("/")) return _lPage(o, p);
+    if (o.iO("/")) return _lPage(o, p);
     if (o === "+") return _lPage(p, p2, true);
     if (o === "-") return _lSel(p);
     if (o === "x") return xhr;            
@@ -219,7 +219,7 @@ pO("getPage", { xhr: 0 }, 0, function (o, p, p2) {
         var ispost = $.rq("is");
                 
         xhr = $.ajax({
-		url: hin,
+        url: hin,
         type: ispost ? "POST" : "GET",
         data: ispost ? $.rq("d") : null,
         success: function (h) {
@@ -492,7 +492,7 @@ pO("cd", { cd: 0, aniTrue: 0, from: 0, cdwidth: 0 }, { aniParams: false, aniTime
     
     if(o === "g") return cd;
 
-	if(o === "i") {
+    if(o === "i") {
         cd = p.first();
         aniTrue = aniTime && aniParams;
         cdwidth = cd.width();
@@ -504,7 +504,7 @@ pO("cd", { cd: 0, aniTrue: 0, from: 0, cdwidth: 0 }, { aniParams: false, aniTime
             height: "100%"
         }, aniParams);
 		
-		aniParams = $.extend({
+        aniParams = $.extend({
             marginRight: cdwidth - aniParams.width
         }, aniParams);
 		
@@ -525,7 +525,7 @@ pO("cd", { cd: 0, aniTrue: 0, from: 0, cdwidth: 0 }, { aniParams: false, aniTime
 	
     if(!p) return;
 	
-	if(!aniTrue) { p(); return; }
+    if(!aniTrue) { p(); return; }
 	
     if (o === "1" || o === "2") {
 		if(o === "1") cd.stop(true, true);
@@ -597,10 +597,10 @@ pO("rq", { ispost: 0, data: 0, same: 0, sema: 0, mode: 0, push: 0, can: 0, e: 0,
         e = p;
         l = e.currentTarget;
         h = l.href;
-		if(sema === h) return false;
+        if(sema === h) return false;
         sema = h;
         return true;
-	}
+    }
     
     if(o === "v") {
         if(!p) return false;
@@ -611,7 +611,7 @@ pO("rq", { ispost: 0, data: 0, same: 0, sema: 0, mode: 0, push: 0, can: 0, e: 0,
         o = "i";
     }
     
-	if(o === "i") {
+    if(o === "i") {
         ispost = false;
         data = null;
         same = false;
@@ -629,7 +629,7 @@ pO("rq", { ispost: 0, data: 0, same: 0, sema: 0, mode: 0, push: 0, can: 0, e: 0,
         return h;
     }
     
-	if(o === "l") return l;
+    if(o === "l") return l;
     if(o === "e") {
         if(p) e = p;
         return e ? e : h; // Return "e" or if not given "h"
@@ -642,21 +642,21 @@ pO("rq", { ispost: 0, data: 0, same: 0, sema: 0, mode: 0, push: 0, can: 0, e: 0,
 
     if(o === "p") {
         if(p) push = p;
-		return push;
+        return push;
     }
     
-	if(o === "s") { var t = p ? p : h;
+    if(o === "s") { var t = p ? p : h;
         same = (_root(t) === _root(currentURL));
-	}
+    }
     
     if(o === "s?") return same;
 	
-	if(o === "is") {
+    if(o === "is") {
         if(p) ispost = p;
         return ispost;
 	}
 	
-	if(o === "d") {
+    if(o === "d") {
         if(p) data = p;
         return data;
 	}
@@ -666,7 +666,7 @@ pO("rq", { ispost: 0, data: 0, same: 0, sema: 0, mode: 0, push: 0, can: 0, e: 0,
         return can;
 	}
 	
-	if(o === "can?") return can && can !== p && !p.iO('#') && !p.iO('?') ? can : p;
+    if(o === "can?") return can && can !== p && !p.iO('#') && !p.iO('?') ? can : p;
 });
 
 pO("frms", { fm: 0, divs: 0}, { forms: "form:not(.no-ajaxy)" }, function (o, p) {

--- a/ajaxify.js
+++ b/ajaxify.js
@@ -113,16 +113,15 @@ function _root(u) { return u.iO('?') ? u.split('?')[0] : u; }
 // 2) $.cache(<URL>) - returns page with specified URL
 // 3) $.cache(<jQuery object>) - saves the page in cache
 pO("cache", { d: false }, 0, function (o) {
-    if (!o) {
-        return d;
-    }
+    if (!o) return d;
+	
     if (typeof o === "string") {
         if(o === "f") { 
             $.pages("f");
             $.log("Cache flushed");
         } else d = $.pages($.memory(o));
         
-		return d;
+        return d;
     }
 
     if (typeof o === "object") {
@@ -134,16 +133,16 @@ pO("cache", { d: false }, 0, function (o) {
 // The stateful Memory plugin
 // Usage: $.memory(<URL>) - returns the same URL if not turned off internally
 pO("memory", { d: false }, { memoryoff: false }, function (h) {
-     d = memoryoff;
-     if (!h || d === true) return false;
-     if (d === false) return h;
-     if (d.iO(", ")) {
-          d = d.split(", ");
-          if (d.iO(h)) return false;
-          else return h;
-     }
+    d = memoryoff;
+    if (!h || d === true) return false;
+    if (d === false) return h;
+    if (d.iO(", ")) {
+         d = d.split(", ");
+         if (d.iO(h)) return false;
+         else return h;
+    }
      
-	 return h == d ? false : h;
+    return h == d ? false : h;
 });
 		
 // The stateful Pages plugin
@@ -158,13 +157,8 @@ pO("pages", { d: [] }, 0, function (h) {
         if (d[i][0] == h) return d[i][1];
     }
 	
-    if (typeof h === "object") {
-        d.push(h);
-    }
-    
-	if (typeof h === "boolean") {
-        return false;
-    }
+    if (typeof h === "object") d.push(h);
+    if (typeof h === "boolean") return false;
 });
 
 // The GetPage plugin
@@ -184,7 +178,7 @@ pO("getPage", { xhr: 0 }, 0, function (o, p, p2) {
     if (o === "x") return xhr;            
     if($.cache()) return $.cache().find(".ajy-" + o);
 }, {
-    lSel: function ($t) { var r; //load page into DOM and handle scripts
+    lSel: function ($t) { //load page into DOM and handle scripts
         pass++;
         _lDivs($t);
         $.scripts($.rq("s?"));
@@ -199,7 +193,7 @@ pO("getPage", { xhr: 0 }, 0, function (o, p, p2) {
          if(p) p();
     },
 		
-	ld: function ($t, $h) {
+    ld: function ($t, $h) {
         $h.find(".ajy-script").each(function(){
             //if(!($(this).attr("src"))) $(this).replaceWith('<script type="text/javascript">' + $(this).text() + '</script>');
             if(!($(this).attr("src"))) $(this).replaceWith('');
@@ -290,8 +284,8 @@ pO("ajaxify", 0, { pluginon: true, deltas: true }, function ($this, options) {
             $.cache(0, s);
             $.memory(0, s);
             return true;
-            }
-        }
+       }
+    }
 );
 
 // The stateful Scripts plugin
@@ -305,18 +299,14 @@ pO("scripts", { $s : false }, { canonical: true, inline: true, inlinehints: fals
         if(!$s) $s = $();
         return true;
     }
-    if (o === "s") {
-        return _allstyle($s.y);
-    }
+    if (o === "s") return _allstyle($s.y);
             
     if (o === "1") { 
         $.detScripts($s);
         return _addScripts(false, $s, settings);
     }
             
-    if (o === "a") {
-        return _alltxts($s.t);
-    }
+    if (o === "a") return _alltxts($s.t);
 
     if (o === "c") {
         if (canonical && $s.can) return $s.can.attr("href");
@@ -528,7 +518,7 @@ pO("cd", { cd: 0, aniTrue: 0, from: 0, cdwidth: 0 }, { aniParams: false, aniTime
     if(!aniTrue) { p(); return; }
 	
     if (o === "1" || o === "2") {
-		if(o === "1") cd.stop(true, true);
+        if(o === "1") cd.stop(true, true);
         cd.animate(o === "1" ? aniParams : from, aniTime, p);
     }
 });
@@ -618,7 +608,7 @@ pO("rq", { ispost: 0, data: 0, same: 0, sema: 0, mode: 0, push: 0, can: 0, e: 0,
         mode = false;
         push = false;
         return l;
-	}
+    }
     
     if(o === "h") { // Access href hard
         if(p) {
@@ -637,7 +627,7 @@ pO("rq", { ispost: 0, data: 0, same: 0, sema: 0, mode: 0, push: 0, can: 0, e: 0,
     
     if(o === "m") {
         if(p) mode = p;
-		return mode;
+        return mode;
     }
 
     if(o === "p") {
@@ -654,7 +644,7 @@ pO("rq", { ispost: 0, data: 0, same: 0, sema: 0, mode: 0, push: 0, can: 0, e: 0,
     if(o === "is") {
         if(p) ispost = p;
         return ispost;
-	}
+    }
 	
     if(o === "d") {
         if(p) data = p;


### PR DESCRIPTION
_This only pertains to the [4nf.org homepage](http://4nf.org/)_
(i.e. you should be able to use the plugin on your site without experiencing this issue)

(I have ruled-out a syntactical error:
Checked the homepage against the [validator](https://validator.w3.org/) - mostly harmless warnings)

If you open the console when opening the [4nf.org homepage](http://4nf.org/), you can **occasionally** spot the following warning:
- **"Warning - empty content selector passed!"**

In this event, the _jQuery selection_ being passed is empty:

I don't know, how it is possible, that the content div 

```
jQuery('#content')
```

...being passed is empty?

Any ideas?
