### PR TITLE
Attempt to address issue #103

### DIFF
--- a/ajaxify.js
+++ b/ajaxify.js
@@ -906,6 +906,7 @@ pO("pronto", { $gthis: 0 }, { selector: "a:not(.no-ajaxy)", prefetch: true, refr
  click: function(e, mode) { //...handler for normal clicks
       var link = $.rq("v", e);  // validate internal URL
       if(!link || _exoticKey(e)) return; // Ignore everything but normal click
+      if(link.href.substr(-1) ==='#') return;
       if(_hashChange(link)) { // only hash has changed
           $.scroll(link.href);
           if(link.href.substr(-1) !=='#') currentURL = link.href;


### PR DESCRIPTION
Simple, conditional "return" inserted.

Please test, whether this has the desired effect...

Assumption: returning "non-false" lets the default click handler to kick in, breaking Ajaxify execution anyway, thus allowing this simple condition...
