### PR TITLE
removeScript inserted into data-class="always" handling

### DIFF
--- a/ajaxify.js
+++ b/ajaxify.js
@@ -473,7 +473,8 @@ pO("addAll", { $scriptsO: false, $scriptsN: false, $sCssO: [], $sCssN: [], $sO: 
                  $.scripts(sN[i][0]); //insert single inline script
                  continue;
              }				 
-             if (sN[i][1] === 0 || _classAlways(sN[i][0])) _iScript(sN[i][0].attr(PK), sN[i][0].attr("async")); //insert single external script in the head
+             if (_classAlways(sN[i][0])) _removeScript(sN[i][0].attr(PK));
+			 if (sN[i][1] === 0 || _classAlways(sN[i][0])) _iScript(sN[i][0].attr(PK), sN[i][0].attr("async")); //insert single external script in the head
         }
     },
     iScript: function ($S, aSync) { 


### PR DESCRIPTION
I have relaxed the data-class="always" handling to work on all pages, not just dynamic ones with the same root URL...

[Demo](http://www.oeko-fakt.de/produkte/)

Is that, what you would expect?

Does [this test file](http://4nf.org/ajaxify.js) work for you?